### PR TITLE
Fixed pointer to source inside std::string

### DIFF
--- a/src/MSAOpenCLProgram.cpp
+++ b/src/MSAOpenCLProgram.cpp
@@ -54,7 +54,8 @@ namespace msa {
 		
 		pOpenCL = OpenCL::currentOpenCL;
 		
-		clProgram = clCreateProgramWithSource(pOpenCL->getContext(), 1, (const char**)&source, NULL, &err);
+		const char* csource = source.c_str();
+		clProgram = clCreateProgramWithSource(pOpenCL->getContext(), 1, &csource, NULL, &err);
 		
 		build();
 	} 


### PR DESCRIPTION
Removed the dirty cast which didn't work (pointed at bad address, perhaps std:: non-string data) in my build. Maybe vis studio doesn't resolve the const char\* operator in the same way as gcc.
Either way, source loads now.
